### PR TITLE
ci: add pull_request types

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
   generate-version:


### PR DESCRIPTION
This pull request makes a small update to the GitHub Actions workflow configuration. The workflow is now triggered for additional pull request events, including when a pull request is opened, synchronized, reopened, or closed.