### PR TITLE
ci: dd pullrequest types

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -1,10 +1,10 @@
-name: Build Application
+name: Build Docker Image
 
 on:
   workflow_call:
     inputs:
       RUNS_ON:
-        description: 'The type of machine to run on. Defaults to ubuntu-24.04.'
+        description: 'The type of machine to run on.'
         required: true
         type: string
         default: ubuntu-24.04
@@ -20,16 +20,32 @@ on:
         description: 'Whether to push the Docker image to the registry.'
         required: true
         type: boolean
-      BUILD_CONTEXT:
-        description: 'The context path for the Docker build. Defaults to the root of the repository.'
+      BUILD_CONTEXT_PATH:
+        description: 'The context path for the Docker build.'
         required: false
         type: string
         default: '.'
+      DOCKERFILE_PATH:
+        description: 'The path to the Dockerfile.'
+        required: true
+        type: string
+      AWS_ACCOUNT_ID:
+        description: 'AWS account ID containing the ECR repository.'
+        required: true
+        type: string
+      AWS_ROLE_ARN:
+        description: 'ARN of the role to assume for pushing to ECR.'
+        required: true
+        type: string
+      AWS_REGION:
+        description: 'AWS region of the ECR repository.'
+        required: true
+        type: string
     secrets:
-      REPOSITORY_USERNAME:
-        description: 'Repository username.'
-      REPOSITORY_TOKEN:
-        description: 'Repository access token.'
+      AWS_ACCESS_KEY_ID:
+        description: 'AWS access key ID of the credentials allowed to assume the role.'
+      AWS_SECRET_ACCESS_KEY:
+        description: 'AWS secret access key of the credentials allowed to assume the role.'
 
 jobs:
   build:
@@ -38,20 +54,24 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v3
         with:
-          username: ${{ secrets.REPOSITORY_USERNAME }}
-          password: ${{ secrets.REPOSITORY_TOKEN }}
+          role-to-assume: ${{ inputs.AWS_ROLE_ARN }}
+          aws-region: ${{ inputs.AWS_REGION }}
+          role-session-name: github-actions-ecr
+
+      - name: Login to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build Docker image
+      - name: Build & Push Docker image
         uses: docker/build-push-action@v6
         with:
-          context: .
-          file: src/Store.Client.Web/Dockerfile
+          context: ${{ inputs.BUILD_CONTEXT_PATH }}
+          file: ${{ inputs.DOCKERFILE_PATH }}
           push: ${{ inputs.PUSH }}
           tags: |
-            ${{ secrets.REPOSITORY_USERNAME }}/${{ inputs.IMAGE_NAME }}:${{ inputs.IMAGE_TAG }}
+            ${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.IMAGE_NAME }}:${{ inputs.IMAGE_TAG }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,7 +20,8 @@ jobs:
       IMAGE_NAME: store-client-web
       IMAGE_TAG: ${{ needs.generate-version.outputs.VERSION }}
       PUSH: true
-      BUILD_CONTEXT: .
-    secrets:
-      REPOSITORY_USERNAME: ${{ secrets.DOCKER_HUB_USERNAME }}
-      REPOSITORY_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
+      BUILD_CONTEXT_PATH: .
+      DOCKERFILE_PATH: src/Store.Client.Web/Dockerfile
+      AWS_ROLE_ARN: arn:aws:iam::120915929317:role/Github-Store
+      AWS_ACCOUNT_ID: 120915929317
+      AWS_REGION: eu-north-1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,10 @@ on:
       - main
     types: [opened, synchronize, reopened, closed]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   generate-version:
     uses: ./.github/workflows/versioning.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,6 +26,6 @@ jobs:
       PUSH: true
       BUILD_CONTEXT_PATH: .
       DOCKERFILE_PATH: src/Store.Client.Web/Dockerfile
-      AWS_ROLE_ARN: arn:aws:iam::120915929317:role/Github-Store
+      AWS_ROLE_ARN: arn:aws:iam::120915929317:role/repository-store
       AWS_ACCOUNT_ID: 120915929317
       AWS_REGION: eu-north-1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
   generate-version:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -21,7 +21,7 @@ jobs:
     uses: ./.github/workflows/build-docker.yaml
     with:
       RUNS_ON: ubuntu-24.04
-      IMAGE_NAME: store-client-web
+      IMAGE_NAME: store/web
       IMAGE_TAG: ${{ needs.generate-version.outputs.VERSION }}
       PUSH: true
       BUILD_CONTEXT_PATH: .


### PR DESCRIPTION
This pull request updates the Docker build and CI workflows to switch from Docker Hub to Amazon ECR for image storage and deployment. It introduces new AWS-related configuration options, updates secrets handling, and modifies the build process to use AWS authentication and ECR login instead of Docker Hub credentials.

**Migration to AWS ECR and workflow improvements:**

* The build workflow (`.github/workflows/build-docker.yaml`) now uses AWS credentials and ECR login for Docker image building and pushing, replacing Docker Hub authentication steps.
* New required workflow inputs are added for AWS integration, including `AWS_ACCOUNT_ID`, `AWS_ROLE_ARN`, and `AWS_REGION`, and secrets for AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`). The Docker context and Dockerfile path inputs have been renamed and clarified.
* The Docker image tag format is updated to use the ECR repository URL instead of the Docker Hub format.
* The CI workflow (`.github/workflows/ci.yaml`) is updated to pass AWS-related parameters to the build workflow and remove Docker Hub secrets.

**Workflow configuration enhancements:**

* The build workflow and CI workflow input descriptions are improved for clarity, and the build workflow name is updated to "Build Docker Image".
* The CI workflow now triggers on additional pull request events (`opened`, `synchronize`, `reopened`, `closed`) for better automation coverage.