### PR TITLE
ci: implement fire event job

### DIFF
--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -46,10 +46,14 @@ on:
         description: 'AWS access key ID of the credentials allowed to assume the role.'
       AWS_SECRET_ACCESS_KEY:
         description: 'AWS secret access key of the credentials allowed to assume the role.'
+      BUILD_ARGUMENTS:
+        description: 'Build arguments to pass to the Docker build.'
+        required: false
     outputs:
       IMAGE_URI:
         description: 'The full URI of the built Docker image.'
         value: ${{ jobs.build.outputs.IMAGE_URI }}
+
 jobs:
   build:
     runs-on: ${{ inputs.RUNS_ON }}
@@ -87,3 +91,5 @@ jobs:
           push: ${{ inputs.PUSH }}
           tags: |
             ${{ steps.generate-full-image-name.outputs.IMAGE_NAME }}
+          build-args: |
+            ${{ fromJSON(secrets.BUILD_ARGUMENTS || '{}') }}

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -42,10 +42,6 @@ on:
         required: true
         type: string
     secrets:
-      AWS_ACCESS_KEY_ID:
-        description: 'AWS access key ID of the credentials allowed to assume the role.'
-      AWS_SECRET_ACCESS_KEY:
-        description: 'AWS secret access key of the credentials allowed to assume the role.'
       BUILD_ARGUMENTS:
         description: 'Build arguments to pass to the Docker build.'
         required: false

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -46,10 +46,15 @@ on:
         description: 'AWS access key ID of the credentials allowed to assume the role.'
       AWS_SECRET_ACCESS_KEY:
         description: 'AWS secret access key of the credentials allowed to assume the role.'
-
+    outputs:
+      IMAGE_URI:
+        description: 'The full URI of the built Docker image.'
+        value: ${{ jobs.build.outputs.IMAGE_URI }}
 jobs:
   build:
     runs-on: ${{ inputs.RUNS_ON }}
+    outputs:
+      IMAGE_URI: ${{ steps.generate-full-image-name.outputs.IMAGE_NAME }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -67,6 +72,13 @@ jobs:
       - name: Setup Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Generate full image name
+        id: generate-full-image-name
+        run: |
+          IMAGE_NAME="${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.IMAGE_NAME }}:${{ inputs.IMAGE_TAG }}"
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_OUTPUT
+
       - name: Build & Push Docker image
         uses: docker/build-push-action@v6
         with:
@@ -74,4 +86,4 @@ jobs:
           file: ${{ inputs.DOCKERFILE_PATH }}
           push: ${{ inputs.PUSH }}
           tags: |
-            ${{ inputs.AWS_ACCOUNT_ID }}.dkr.ecr.${{ inputs.AWS_REGION }}.amazonaws.com/${{ inputs.IMAGE_NAME }}:${{ inputs.IMAGE_TAG }}
+            ${{ steps.generate-full-image-name.outputs.IMAGE_NAME }}

--- a/.github/workflows/build-docker.yaml
+++ b/.github/workflows/build-docker.yaml
@@ -43,7 +43,7 @@ on:
         type: string
     secrets:
       BUILD_ARGUMENTS:
-        description: 'Build arguments to pass to the Docker build.'
+        description: 'Build arguments to pass to the Docker build. Should be a JSON object. For example {"EXPOSED_PORT": "8080"}.'
         required: false
     outputs:
       IMAGE_URI:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,7 @@ jobs:
     with:
       RUNS_ON: ubuntu-24.04
       NODE_VERSION: '22'
+
   build-image:
     needs: generate-version
     uses: ./.github/workflows/build-docker.yaml
@@ -29,3 +30,18 @@ jobs:
       AWS_ROLE_ARN: arn:aws:iam::120915929317:role/repository-store
       AWS_ACCOUNT_ID: 120915929317
       AWS_REGION: eu-north-1
+
+  fire-event:
+    needs: build-image
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Generate deployment event
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          repository: TheSteelMinistry/gitops-demo
+          token: ${{ secrets.GITHUB_TOKEN }}
+          event-type: new-image
+          client-payload: '{
+              "workload": "store",
+              "image": "${{ needs.build-image.outputs.IMAGE_URI }}"
+            }'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,11 @@ jobs:
       AWS_ROLE_ARN: arn:aws:iam::120915929317:role/repository-store
       AWS_ACCOUNT_ID: 120915929317
       AWS_REGION: eu-north-1
-
+    secrets:
+      BUILD_ARGUMENTS: '{
+          "EXPOSED_PORT": "8080"
+        }'
+        
   fire-event:
     needs: build-image
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -39,7 +39,7 @@ jobs:
         uses: peter-evans/repository-dispatch@v3
         with:
           repository: TheSteelMinistry/gitops-demo
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.DEPLOYMENT_KEY }}
           event-type: new-image
           client-payload: '{
               "workload": "store",

--- a/.github/workflows/versioning.yaml
+++ b/.github/workflows/versioning.yaml
@@ -11,6 +11,11 @@ on:
         description: 'The Node.js version to use. Defaults to 22.'
         default: '22'
         type: string
+      FLAVOUR:
+        description: 'The flavour of the application.'
+        default: ''
+        type: string
+        required: false
     outputs:
       VERSION:
         description: 'The generated version.'
@@ -59,5 +64,10 @@ jobs:
           TIMESTAMP=$(date +"%Y%m%d.%H%M")
           PR=${{ github.event.pull_request.number }}
           VERSION="${TIMESTAMP}.${PR}-${CODENAME}"
+
+          if [ -n "${{ inputs.FLAVOUR }}" ]; then
+            VERSION="${VERSION}-${{ inputs.FLAVOUR }}"
+          fi
+
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "VERSION=$VERSION" >> $GITHUB_OUTPUT

--- a/src/Store.Client.Web/Dockerfile
+++ b/src/Store.Client.Web/Dockerfile
@@ -18,9 +18,12 @@ RUN dotnet publish -c Release -o /app/publish /p:UseAppHost=false
 
 # STAGE 2: Runtime
 FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS final
+
+ARG EXPOSED_PORT
+
 WORKDIR /app
 COPY --from=build /app/publish .
 
-EXPOSE 8080
+EXPOSE ${EXPOSED_PORT}
 
 ENTRYPOINT ["dotnet", "Store.Client.Web.dll"]


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows to improve Docker image build and deployment automation, and adds support for application "flavours" in versioning. The changes enhance how Docker image URIs are generated and passed between workflows, and introduce an event to trigger deployments with the correct image reference. Additionally, the versioning workflow now allows for custom "flavour" tags.

**Docker build and deployment workflow improvements:**

* The `build-docker.yaml` workflow now generates the full Docker image URI in a dedicated step (`generate-full-image-name`) and exposes it as an output, making it available for downstream jobs and workflows. [[1]](diffhunk://#diff-97e1e79b4ecbd5261fd1b1a49312400b613bd1953d84d3485019f8eb0667d2e6L49-R57) [[2]](diffhunk://#diff-97e1e79b4ecbd5261fd1b1a49312400b613bd1953d84d3485019f8eb0667d2e6R75-R89)
* The `ci.yaml` workflow uses the new output from the Docker build job to trigger a `fire-event` job, which dispatches a deployment event (via `repository-dispatch`) with the correct image URI in the payload.

**Versioning workflow enhancements:**

* The `versioning.yaml` workflow introduces a new optional input, `FLAVOUR`, allowing the generated version string to include a flavour suffix if specified. This enables building and tagging different variants of the application. [[1]](diffhunk://#diff-67cc7f4d3d06063e6239e59de699c4a2c768ba544777ded6aa22ab45aa0ad24aR14-R18) [[2]](diffhunk://#diff-67cc7f4d3d06063e6239e59de699c4a2c768ba544777ded6aa22ab45aa0ad24aR67-R71)

**Other workflow updates:**

* Minor formatting and input changes in `ci.yaml` to support the new build and deployment steps.